### PR TITLE
Allow compatibility with other model providers other than LMStudio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Orpheus-TTS-Local
 
-A lightweight client for running [Orpheus TTS](https://huggingface.co/canopylabs/orpheus-3b-0.1-ft) locally using LM Studio API.
+A lightweight client for running [Orpheus TTS](https://huggingface.co/canopylabs/orpheus-3b-0.1-ft) locally using OpenAI compatible API (e.g. those served via LM Studio, Llama.cpp/Ollama, or OpenWebUI).
 
 ## Features
 
@@ -11,17 +11,23 @@ A lightweight client for running [Orpheus TTS](https://huggingface.co/canopylabs
 
 ## Quick Setup
 
-1. Install [LM Studio](https://lmstudio.ai/) 
-2. Download the [Orpheus TTS model (orpheus-3b-0.1-ft-q4_k_m.gguf)](https://huggingface.co/isaiahbjork/orpheus-3b-0.1-ft-Q4_K_M-GGUF) in LM Studio
-3. Load the Orpheus model in LM Studio
-4. Start the local server in LM Studio (default: http://127.0.0.1:1234)
-5. Install dependencies:
+1. Install [LM Studio](https://lmstudio.ai/), [Ollama](https://https://ollama.com/download), or [Llama.cpp's Server](https://github.com/ggml-org/llama.cpp)
+2. Download the [Orpheus TTS model (orpheus-3b-0.1-ft-q4_k_m.gguf)](https://huggingface.co/isaiahbjork/orpheus-3b-0.1-ft-Q4_K_M-GGUF) in your inference engine of choice
+  - For Ollama, do `ollama pull hf.co/isaiahbjork/orpheus-3b-0.1-ft-Q4_K_M-GGUF`
+3. Start up the model For LM Studio
+  - Load the Orpheus model in LM Studio
+  - Start the local server in LM Studio (default: http://127.0.0.1:1234)
+4. Install dependencies:
    ```
    python3 -m venv venv
    source venv/bin/activate
    pip install -r requirements.txt
    ```
-6. Run the script:
+5. (For OpenAI compatible endpoint users = Non-LM Studio) Set environment variables as needed
+  - export API_PATH=<your_server_url> (e.g. for Ollama, use http://localhost:11434/v1/chat/completions, for OpenWebUI, use http://your_server_url/api/chat/completions)
+  - export API_KEY=<your_api_key> (if you've set an API key to be required)
+  - export MODEL_NAME=<your_model_name> (if you've set a custom model name in your inference engine)
+5. Run the script:
    ```
    python gguf_orpheus.py --text "Hello, this is a test" --voice tara
    ```

--- a/gguf_orpheus.py
+++ b/gguf_orpheus.py
@@ -12,7 +12,8 @@ import queue
 import asyncio
 
 # LM Studio API settings
-API_URL = "http://127.0.0.1:1234/v1/completions"
+# API_URL = "http://127.0.0.1:1234/v1/completions"
+API_URL = "http://hpserver.local:3113/api/chat/completions"
 HEADERS = {
     "Content-Type": "application/json"
 }
@@ -56,8 +57,11 @@ def generate_tokens_from_api(prompt, voice=DEFAULT_VOICE, temperature=TEMPERATUR
     
     # Create the request payload for the LM Studio API
     payload = {
-        "model": "orpheus-3b-0.1-ft-q4_k_m",  # Model name can be anything, LM Studio ignores it
-        "prompt": formatted_prompt,
+        # Model name is used by endpoints such as those by OpenWebUI or OLLAMA
+        "model": "hf.co/isaiahbjork/orpheus-3b-0.1-ft-Q4_K_M-GGUF:latest",
+        #"model": "orpheus-3b-0.1-ft-q4_k_m",  # Model name can be anything, LM Studio ignores it
+        #"prompt": formatted_prompt,
+        "messages": [{"role": "system", "content": [{"type": "text", "text": formatted_prompt}]}],
         "max_tokens": max_tokens,
         "temperature": temperature,
         "top_p": top_p,
@@ -78,7 +82,9 @@ def generate_tokens_from_api(prompt, voice=DEFAULT_VOICE, temperature=TEMPERATUR
     for line in response.iter_lines():
         if line:
             line = line.decode('utf-8')
+            print("line:"+line)
             if line.startswith('data: '):
+                print("gotline:"+line)
                 data_str = line[6:]  # Remove the 'data: ' prefix
                 if data_str.strip() == '[DONE]':
                     break
@@ -86,7 +92,8 @@ def generate_tokens_from_api(prompt, voice=DEFAULT_VOICE, temperature=TEMPERATUR
                 try:
                     data = json.loads(data_str)
                     if 'choices' in data and len(data['choices']) > 0:
-                        token_text = data['choices'][0].get('text', '')
+                        # use the more modern "chat completions" API instead
+                        token_text = data['choices'][0].get('delta', {}).get('content', '')
                         token_counter += 1
                         if token_text:
                             yield token_text

--- a/gguf_orpheus.py
+++ b/gguf_orpheus.py
@@ -13,10 +13,14 @@ import asyncio
 
 # LM Studio API settings
 # API_URL = "http://127.0.0.1:1234/v1/completions"
-API_URL = "http://hpserver.local:3113/api/chat/completions"
+API_URL = os.environ.get("API_URL", "http://127.0.0.1:1234/v1/chat/completions") 
+API_KEY = os.environ.get("API_KEY", "")
 HEADERS = {
     "Content-Type": "application/json"
 }
+if API_KEY:
+    HEADERS["Authorization"] = "Bearer "+API_KEY
+MODEL_NAME = os.environ.get("MODEL_NAME", "hf.co/isaiahbjork/orpheus-3b-0.1-ft-Q4_K_M-GGUF:latest")
 
 # Model parameters
 MAX_TOKENS = 1200
@@ -58,7 +62,8 @@ def generate_tokens_from_api(prompt, voice=DEFAULT_VOICE, temperature=TEMPERATUR
     # Create the request payload for the LM Studio API
     payload = {
         # Model name is used by endpoints such as those by OpenWebUI or OLLAMA
-        "model": "hf.co/isaiahbjork/orpheus-3b-0.1-ft-Q4_K_M-GGUF:latest",
+        # LM Studio ignores it though.
+        "model": MODEL_NAME,
         #"model": "orpheus-3b-0.1-ft-q4_k_m",  # Model name can be anything, LM Studio ignores it
         #"prompt": formatted_prompt,
         "messages": [{"role": "system", "content": [{"type": "text", "text": formatted_prompt}]}],
@@ -82,9 +87,7 @@ def generate_tokens_from_api(prompt, voice=DEFAULT_VOICE, temperature=TEMPERATUR
     for line in response.iter_lines():
         if line:
             line = line.decode('utf-8')
-            print("line:"+line)
             if line.startswith('data: '):
-                print("gotline:"+line)
                 data_str = line[6:]  # Remove the 'data: ' prefix
                 if data_str.strip() == '[DONE]':
                     break


### PR DESCRIPTION
This PR adds support for environment variables API_URL, API_KEY, and MODEL_NAME for use with other inference providers that are OpenAI API compatible. This includes LLaMA.cpp's server example, Ollama, and OpenWebUI.

It also changes the code to use the newer (non-legacy) chat completions endpoint.