### PR TITLE
add voice cloning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ sounddevice>=0.4.4
 requests>=2.25.0
 wave>=0.0.2 
 snac>=1.2.1
+librosa
+transformers


### PR DESCRIPTION
This PR adds voice cloning support for the pretrained (not finetuned) model. The ggufs for that model can be found [here](https://huggingface.co/Annuvin/orpheus-3b-0.1-pt-GGUF). Voice cloning quality varies. A wav file and a transcript are required. I also added a commandline parameter for max_tokens. Normal TTS generation still works like before. The way the prompt is tokenized is not ideal as we have to tokenize it manually and then detokenize using the transformers tokenizer, but thats how the colab does it.